### PR TITLE
chore(tests): Add some unit tests for response models

### DIFF
--- a/src/adzerk/response_models.rs
+++ b/src/adzerk/response_models.rs
@@ -197,12 +197,14 @@ fn map_priority(priority_id: Option<u32>) -> u32 {
 fn get_cdn_image(full_image_path: &str) -> Result<String, ProxyError> {
     match full_image_path.parse::<Uri>()?.host() {
         Some(domain) if domain.ends_with(".zkcdn.net") || domain == "zkcdn.net" => {
-            let result = "https://img-getpocket.cdn.mozilla.net/direct";
             let url = form_urlencoded::Serializer::new(String::new())
                 .append_pair("url", full_image_path)
                 .append_pair("resize", "w618-h310")
                 .finish();
-            Ok(format!("{}?{}", result, url))
+            Ok(format!(
+                "https://img-getpocket.cdn.mozilla.net/direct?{}",
+                url
+            ))
         }
         _ => Err(ProxyError::new(format!(
             "Invalid AdZerk image url: {}",

--- a/src/adzerk/response_models.rs
+++ b/src/adzerk/response_models.rs
@@ -285,7 +285,8 @@ fn tracking_url_to_shim(url: String) -> Result<String, ProxyError> {
 mod tests {
     use super::Decision;
     use crate::adzerk::response_models::{
-        clean_sponsored_by_override, get_cdn_image, get_is_video, tracking_url_to_shim,
+        clean_sponsored_by_override, get_cdn_image, get_is_video, get_personalization_models,
+        tracking_url_to_shim,
     };
     use std::collections::HashMap;
 
@@ -353,5 +354,17 @@ mod tests {
         for (key, value) in test_map {
             assert_eq!(get_cdn_image(key).unwrap(), value);
         }
+    }
+
+    #[test]
+    fn test_get_personalization_models() {
+        let test_string = Some(String::from("{\"topic_fun\": true}"));
+        let mut test_result: HashMap<String, u32> = HashMap::new();
+        test_result.insert("fun".to_string(), 1);
+
+        assert_eq!(
+            get_personalization_models(test_string).unwrap(),
+            test_result
+        );
     }
 }

--- a/src/adzerk/response_models.rs
+++ b/src/adzerk/response_models.rs
@@ -197,12 +197,12 @@ fn map_priority(priority_id: Option<u32>) -> u32 {
 fn get_cdn_image(full_image_path: &str) -> Result<String, ProxyError> {
     match full_image_path.parse::<Uri>()?.host() {
         Some(domain) if domain.ends_with(".zkcdn.net") || domain == "zkcdn.net" => {
-            let mut result = "https://img-getpocket.cdn.mozilla.net/direct?".to_owned();
-            form_urlencoded::Serializer::new(&mut result)
+            let result = "https://img-getpocket.cdn.mozilla.net/direct";
+            let url = form_urlencoded::Serializer::new(String::new())
                 .append_pair("url", full_image_path)
                 .append_pair("resize", "w618-h310")
                 .finish();
-            Ok(result)
+            Ok(format!("{}?{}", result, url))
         }
         _ => Err(ProxyError::new(format!(
             "Invalid AdZerk image url: {}",
@@ -283,10 +283,9 @@ fn tracking_url_to_shim(url: String) -> Result<String, ProxyError> {
 
 #[cfg(test)]
 mod tests {
-    use super::Decision;
-    use crate::adzerk::response_models::{
+    use super::{
         clean_sponsored_by_override, get_cdn_image, get_is_video, get_personalization_models,
-        tracking_url_to_shim,
+        tracking_url_to_shim, Decision,
     };
     use std::collections::HashMap;
 
@@ -297,70 +296,61 @@ mod tests {
 
     #[test]
     fn test_tracking_url_to_shim() {
-        let test_string: String = "https://example.local/r?e=123&s=456&j=789".to_string();
+        let test_string: String = "https://example.local/r?e=123&s=456&j=789".to_owned();
         let test_result = tracking_url_to_shim(test_string).unwrap();
         assert_eq!(test_result, "0,123,456")
     }
 
     #[test]
     fn test_is_video() {
-        let test_map: HashMap<Option<String>, Option<bool>> = [
-            (Some(String::from("t")), Some(true)),
-            (Some(String::from("off")), Some(false)),
-            (Some(String::from("1")), Some(true)),
-        ]
-        .iter()
-        .cloned()
-        .collect();
+        let test_cases = [
+            (Some("t".to_owned()), Some(true)),
+            (Some("off".to_owned()), Some(false)),
+            (Some("1".to_owned()), Some(true)),
+        ];
 
-        for (key, value) in test_map {
+        for (key, value) in test_cases {
             assert_eq!(get_is_video(key), value);
         }
     }
 
     #[test]
     fn test_clean_sponsored_by_override() {
-        let test_map: HashMap<&str, &str> = [
+        let test_cases = [
             ("        blank", ""),
             ("king fisher", "king fisher"),
             ("", ""),
-        ]
-        .iter()
-        .cloned()
-        .collect();
+        ];
 
-        for (key, value) in test_map {
+        for (key, value) in test_cases {
             assert_eq!(
-                clean_sponsored_by_override(key.to_string()),
-                value.to_string()
+                clean_sponsored_by_override(key.to_owned()),
+                value.to_owned()
             );
         }
     }
 
     #[test]
     fn test_get_cdn_image() {
-        let image_url = "https://img-getpocket.cdn.mozilla.net/direct?";
-        let test_map: HashMap<&str, String> = [(
+        let image_url = "https://img-getpocket.cdn.mozilla.net/direct";
+        let test_cases = [(
             "https://subdomain.zkcdn.net/foo/bar",
             format!(
-                "{}&url=https%3A%2F%2Fsubdomain.zkcdn.net%2Ffoo%2Fbar&resize=w618-h310",
+                "{}?url=https%3A%2F%2Fsubdomain.zkcdn.net%2Ffoo%2Fbar&resize=w618-h310",
                 image_url
             ),
-        )]
-        .iter()
-        .cloned()
-        .collect();
+        )];
 
-        for (key, value) in test_map {
+        for (key, value) in test_cases {
             assert_eq!(get_cdn_image(key).unwrap(), value);
         }
     }
 
     #[test]
     fn test_get_personalization_models() {
-        let test_string = Some(String::from("{\"topic_fun\": true}"));
+        let test_string = Some("{\"topic_fun\": true}".to_owned());
         let mut test_result: HashMap<String, u32> = HashMap::new();
-        test_result.insert("fun".to_string(), 1);
+        test_result.insert("fun".to_owned(), 1);
 
         assert_eq!(
             get_personalization_models(test_string).unwrap(),


### PR DESCRIPTION
@smarnach on my local machine the following test (not one I added) always fails. It looks like we are expecting a string but the test mock has a float. We actually convert the string to a float in the code so I'm not sure what we expect from Adzerk.

```
---- adzerk::response_models::tests::test_deserialize_decisions stdout ----
thread 'adzerk::response_models::tests::test_deserialize_decisions' panicked at 'called `Result::unwrap()` on an `Err` value: Error("invalid type: floating point `0.01`, expected a string", line: 24, column: 39)', src/adzerk/response_models.rs:294:89
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```