### PR TITLE
chore(proxies): Trust all proxies

### DIFF
--- a/src/endpoints/mod.rs
+++ b/src/endpoints/mod.rs
@@ -8,7 +8,6 @@ use std::{default::Default, path::PathBuf, sync::Arc};
 #[derive(Debug, Clone)]
 pub struct EndpointState {
     pub geoip: Arc<GeoIp>,
-    pub trusted_proxies: Vec<ipnet::IpNet>,
     pub log: slog::Logger,
     pub metrics: Arc<cadence::StatsdClient>,
     pub version_file: PathBuf,
@@ -17,7 +16,6 @@ pub struct EndpointState {
 impl Default for EndpointState {
     fn default() -> Self {
         EndpointState {
-            trusted_proxies: Vec::default(),
             geoip: Arc::new(GeoIp::default()),
             log: slog::Logger::root(slog::Discard, slog::o!()),
             metrics: Arc::new(cadence::StatsdClient::from_sink(

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,6 @@ async fn main() -> Result<(), ProxyError> {
         human_logs,
         metrics_target,
         port,
-        trusted_proxy_list,
         version_file,
         adzerk_api_key,
         ..
@@ -57,7 +56,6 @@ async fn main() -> Result<(), ProxyError> {
                 .build()?,
         ),
         metrics,
-        trusted_proxies: trusted_proxy_list,
         log: app_log.clone(),
         version_file,
     };


### PR DESCRIPTION
This is similar to the middleware in the python implementation. We are just trusting all proxies.